### PR TITLE
Fix issue with xCode 8 (and iOS9)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -14,8 +14,8 @@
             <clobbers target="ApplePay" />
         </js-module>
 
-        <framework src="PassKit.framework"/>
         <framework src="AddressBook.framework"/>
+        <framework src="PassKit.framework"/>
 
         <header-file src="src/ios/CDVApplePay.h"/>
         <source-file src="src/ios/CDVApplePay.m"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,6 +15,7 @@
         </js-module>
 
         <framework src="PassKit.framework"/>
+        <framework src="AddressBook.framework"/>
 
         <header-file src="src/ios/CDVApplePay.h"/>
         <source-file src="src/ios/CDVApplePay.m"/>


### PR DESCRIPTION
Adding the plugin without enabling the AddressBook framework, makes the app crash in the moment that it's open.
The issue happens if the app is built with XCode 8, on XCode 7 seems to work fine.

