### PR TITLE
Added missing comma after countryCode in ApplePay.makePaymentRequest …

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ ApplePay.makePaymentRequest(
           ],
           merchantIdentifier: 'merchant.apple.test',
           currencyCode: 'GBP',
-          countryCode: 'GB'
+          countryCode: 'GB',
           billingAddressRequirement: 'none',
           shippingAddressRequirement: 'none',
           shippingType: 'shipping'


### PR DESCRIPTION
Added missing comma after countryCode in ApplePay.makePaymentRequest example in the README.md.

This should fix #17  😄 