### PR TITLE
Shipping contact select event

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ properties are:
  * `email`
  * `phone`
 
+You can set these as an array if you want, for example,
+`['name', 'email', 'phone']`.
+
 ## Limitations and TODOs
 * *Supported Payment Networks hard coded* (Visa, Mastercard, American Express) - This should be updated to be passed along in the order, but is rarely changed and trivial to alter in code.
 * *Merchant Capabilities hard coded (3DS)* - This should be updated to be passed along in the order, but is rarely changed and trivial to alter in code.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ The methods available all return promises, or accept success and error callbacks
 - ApplePay.canMakePayments
 - ApplePay.makePaymentRequest
 - ApplePay.completeLastTransaction
+- ApplePay.startListeningForShippingContactSelection - This does _not_ return a promise, but it fires the success callback upon shipping contact selection. See below.
+- ApplePay.updateItemsAndShippingMethods
+- ApplePay.stopListeningForShippingContactSelection
 
 ## ApplePay.canMakePayments
 Detects if the current device supports Apple Pay and has any *capable* cards registered.
@@ -197,6 +200,70 @@ properties are:
 
 You can set these as an array if you want, for example,
 `['name', 'email', 'phone']`.
+
+## Responding to User Shipping Contact Selection Events
+Use the following methods together to work with user shipping contact selection events.
+
+### ApplePay.startListeningForShippingContactSelection
+Starts listening for shipping contact selection changes Any time the user selects shipping contact, this callback will fire.  You *must* call `ApplePay.updateItemsAndShippingMethods` (see below) in response or else the user will not be able to process payment. Apple Pay waits for a completion method to be called to update these proprties before allowing the user to process payments.
+
+Any time the user updates their shipping contact, the success callback to this method will trigger. Then, you must update the items / shipping methods as a result of the user's selection.
+
+You can also call `ApplePay.stopListeningForShippingContactSelection` to stop listening for shipping contact selection changes. Then, you no longer have to call `updateItemsAndShippingMethods` on shipping method selection.
+
+### ApplePay.updateItemsAndShippingMethods
+Call this in response to any `startListeningForShippingContactSelection` event. Provide a list similar to `makePaymentRequest` including `items` and `shippingMethods` arrays. The other properties are not used.
+
+This method returns a promise that wraps the shipping contact selection completion method and should generally succeed.
+
+### ApplePay.stopListeningForShippingContactSelection
+Call this when you no longer need to listen to shipping contact selection events or after completing a transaction attempt.
+
+This method returns a promise that wraps unsubscribing from the Apple Pay event internally. The Promise will be rejected if you were not subscribed to listen to these events initially.
+
+### Example
+
+```
+// Set this up initially. This will also fire if the user has a default
+// shipping contact in the apple pay sheet
+ApplePay.startListeningForShippingContactSelection(async selection => {
+    const { items, shippingMethods } = getItemsAndMethodsFromAddressInfo(
+        selection.shippingAddressCity,
+        selection.shippingAddressState,
+        selection.shippingPostalCode,
+        selection.shippingISOCountryCode, // this is capitalized
+    );
+
+    try {
+        await ApplePay.updateItemsAndShippingMethods({ items, shippingMethods });
+    }
+    catch (e) {
+        // handle error if shipping contact selection couldn't complete for some reason
+    }
+});
+
+try {
+    const response = await ApplePay.makePaymentRequest(paymentRequestOptions);
+    const success = await MyPaymentProvider.authorize(response.paymentData);
+
+    if (success) {
+        await ApplePay.completeLastTransaction('success');
+    }
+    else {
+        await ApplePay.completeLastTransaction('failure');
+    }
+}
+catch (err) {
+    // handle payment request or transaction errors
+}
+
+try {
+    await ApplePay.stopListeningForShippingContactSelection();
+}
+catch (err) {
+    // handle error if you could not unsubscribe from shipping contact selection events
+}
+```
 
 ## Limitations and TODOs
 * *Supported Payment Networks hard coded* (Visa, Mastercard, American Express) - This should be updated to be passed along in the order, but is rarely changed and trivial to alter in code.

--- a/src/ios/CDVApplePay.h
+++ b/src/ios/CDVApplePay.h
@@ -4,6 +4,7 @@
 #import <PassKit/PassKit.h>
 
 typedef void (^ARAuthorizationBlock)(PKPaymentAuthorizationStatus);
+typedef void (^ARListUpdateBlock)(PKPaymentAuthorizationStatus, NSArray<PKShippingMethod *>*, NSArray<PKPaymentSummaryItem *>*);
 
 @interface CDVApplePay : CDVPlugin <PKPaymentAuthorizationViewControllerDelegate>
 {
@@ -13,11 +14,21 @@ typedef void (^ARAuthorizationBlock)(PKPaymentAuthorizationStatus);
 
 @property (nonatomic, strong) ARAuthorizationBlock paymentAuthorizationBlock;
 
+@property (nonatomic, strong) ARListUpdateBlock updateItemsAndShippingMethodsBlock;
+
 @property (nonatomic, strong) NSString* paymentCallbackId;
 
+@property (nonatomic, strong) NSString* shippingContactSelectionListenerCallbackId;
+
+@property (nonatomic, strong) NSArray<PKShippingMethod *>* shippingMethods;
+
+@property (nonatomic, strong) NSArray<PKPaymentSummaryItem *>* summaryItems;
+
 - (void)makePaymentRequest:(CDVInvokedUrlCommand*)command;
+- (void)startListeningForShippingContactSelection:(CDVInvokedUrlCommand*)command;
+- (void)stopListeningForShippingContactSelection:(CDVInvokedUrlCommand*)command;
+- (void)updateItemsAndShippingMethods:(CDVInvokedUrlCommand*)command;
 - (void)canMakePayments:(CDVInvokedUrlCommand*)command;
 - (void)completeLastTransaction:(CDVInvokedUrlCommand*)command;
-
 
 @end

--- a/src/ios/CDVApplePay.m
+++ b/src/ios/CDVApplePay.m
@@ -18,176 +18,15 @@
     merchantCapabilities = PKMerchantCapability3DS;// PKMerchantCapabilityEMV;
 }
 
-- (NSMutableDictionary*)applyABRecordBillingAddress:(ABRecordRef)address forDictionary:(NSMutableDictionary*)response {
-    NSString *address1;
-    NSString *city;
-    NSString *postcode;
-    NSString *state;
-    NSString *country;
-    NSString *countryCode;
-    //NSString *emailAddress;
-    
-    
-    // TODO: Validate email
-    
-    //    if (shippingContact.emailAddress) {
-    //        [response setObject:shippingContact.emailAddress forKey:@"billingEmailAddress"];
-    //    }
-    //
-    //    if (shippingContact.supplementarySubLocality) {
-    //        [response setObject:shippingContact.supplementarySubLocality forKey:@"billingSupplementarySubLocality"];
-    //    }
-    
-    
-    //emailAddress = (__bridge NSString *)(CFDictionaryGetValue(address, kABPersonEmailProperty));
-    
-    
-    ABMultiValueRef addressRecord = ABRecordCopyValue(address, kABPersonAddressProperty);
-    if (ABMultiValueGetCount(addressRecord) > 0) {
-        CFDictionaryRef dict = ABMultiValueCopyValueAtIndex(addressRecord, 0);
-        
-        address1 = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressStreetKey));
-        city = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressCityKey));
-        postcode = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressZIPKey));
-        state = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressStateKey));
-        country = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressCountryKey));
-        countryCode = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressCountryCodeKey));
-        
-        
-        if (address1) {
-            [response setObject:address1 forKey:@"billingAddressStreet"];
-        }
-        
-        if (city) {
-            [response setObject:city forKey:@"billingAddressCity"];
-        }
-        
-        if (postcode) {
-            [response setObject:postcode forKey:@"billingPostalCode"];
-        }
-        
-        if (state) {
-            [response setObject:state forKey:@"billingAddressState"];
-        }
-        
-        if (country) {
-            [response setObject:country forKey:@"billingCountry"];
-        }
-        
-        if (countryCode) {
-            [response setObject:countryCode forKey:@"billingISOCountryCode"];
-        }
-        
-    }
-    
-    // TODO: Valdidate address
-    
-    //    BOOL valid = (address1 && ![address1 isEqualToString:@""] &&
-    //                  city && ![city isEqualToString:@""] &&
-    //                  postcode && ![postcode isEqualToString:@""] &&
-    //                  country && ![country isEqualToString:@""]);
-    //
-    //    if ([selectedCountry isEqualToString:@"United States"]) {
-    //        valid = (valid && state && ![state isEqualToString:@""]);
-    //    }
-    return response;
-}
-
-- (NSMutableDictionary*)applyABRecordShippingAddress:(ABRecordRef)address forDictionary:(NSMutableDictionary*)response {
-    NSString *address1;
-    NSString *city;
-    NSString *postcode;
-    NSString *state;
-    NSString *country;
-    NSString *countryCode;
-    //NSString *emailAddress;
-    
-    
-    // TODO: Validate email
-    
-    //    if (shippingContact.emailAddress) {
-    //        [response setObject:shippingContact.emailAddress forKey:@"shippingEmailAddress"];
-    //    }
-    //
-    //    if (shippingContact.supplementarySubLocality) {
-    //        [response setObject:shippingContact.supplementarySubLocality forKey:@"shippingSupplementarySubLocality"];
-    //    }
-    
-    
-    //emailAddress = (__bridge NSString *)(CFDictionaryGetValue(address, kABPersonEmailProperty));
-    
-    
-    ABMultiValueRef addressRecord = ABRecordCopyValue(address, kABPersonAddressProperty);
-    if (ABMultiValueGetCount(addressRecord) > 0) {
-        CFDictionaryRef dict = ABMultiValueCopyValueAtIndex(addressRecord, 0);
-        
-        address1 = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressStreetKey));
-        city = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressCityKey));
-        postcode = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressZIPKey));
-        state = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressStateKey));
-        country = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressCountryKey));
-        countryCode = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressCountryCodeKey));
-        
-        
-        if (address1) {
-            [response setObject:address1 forKey:@"shippingAddressStreet"];
-        }
-        
-        if (city) {
-            [response setObject:city forKey:@"shippingAddressCity"];
-        }
-        
-        if (postcode) {
-            [response setObject:postcode forKey:@"shippingPostalCode"];
-        }
-        
-        if (state) {
-            [response setObject:state forKey:@"shippingAddressState"];
-        }
-        
-        if (country) {
-            [response setObject:country forKey:@"shippingCountry"];
-        }
-        
-        if (countryCode) {
-            [response setObject:countryCode forKey:@"shippingISOCountryCode"];
-        }
-        
-    }
-    
-    // TODO: Valdidate address
-    
-    //    BOOL valid = (address1 && ![address1 isEqualToString:@""] &&
-    //                  city && ![city isEqualToString:@""] &&
-    //                  postcode && ![postcode isEqualToString:@""] &&
-    //                  country && ![country isEqualToString:@""]);
-    //
-    //    if ([selectedCountry isEqualToString:@"United States"]) {
-    //        valid = (valid && state && ![state isEqualToString:@""]);
-    //    }
-    return response;
-}
-
-
 - (void)canMakePayments:(CDVInvokedUrlCommand*)command
 {
     if ([PKPaymentAuthorizationViewController canMakePayments]) {
-        if ((floor(NSFoundationVersionNumber) < NSFoundationVersionNumber_iOS_8_0)) {
+        if ((floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_8_0)) {
             CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"This device cannot make payments."];
             [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
             return;
         } else if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 0, 0}]) {
             if ([PKPaymentAuthorizationViewController canMakePaymentsUsingNetworks:supportedPaymentNetworks capabilities:(merchantCapabilities)]) {
-                CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @"This device can make payments and has a supported card"];
-                [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
-                return;
-            } else {
-                CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"This device can make payments but has no supported cards"];
-                [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
-                return;
-            }
-        } else if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){8, 0, 0}]) {
-            if ([PKPaymentAuthorizationViewController canMakePaymentsUsingNetworks:supportedPaymentNetworks]) {
                 CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @"This device can make payments and has a supported card"];
                 [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
                 return;
@@ -454,139 +293,119 @@
     [response setObject:paymentData  forKey:@"paymentData"];
     [response setObject:payment.token.transactionIdentifier  forKey:@"transactionIdentifier"];
     
-    // Different version of iOS present the billing/shipping addresses in different ways. Pain.
-    if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 0, 0}]) {
+    PKContact *billingContact = payment.billingContact;
+    if (billingContact) {
+        if (billingContact.emailAddress) {
+            [response setObject:billingContact.emailAddress forKey:@"billingEmailAddress"];
+        }
         
-        
-        PKContact *billingContact = payment.billingContact;
-        if (billingContact) {
-            if (billingContact.emailAddress) {
-                [response setObject:billingContact.emailAddress forKey:@"billingEmailAddress"];
-            }
-            
-            if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 2, 0}]) {
-                if (billingContact.supplementarySubLocality) {
-                    [response setObject:billingContact.supplementarySubLocality forKey:@"billingSupplementarySubLocality"];
-                }
-            }
-            
-            if (billingContact.name) {
-                
-                if (billingContact.name.givenName) {
-                    [response setObject:billingContact.name.givenName forKey:@"billingNameFirst"];
-                }
-                
-                if (billingContact.name.middleName) {
-                    [response setObject:billingContact.name.middleName forKey:@"billingNameMiddle"];
-                }
-                
-                if (billingContact.name.familyName) {
-                    [response setObject:billingContact.name.familyName forKey:@"billingNameLast"];
-                }
-                
-            }
-            
-            if (billingContact.postalAddress) {
-                
-                if (billingContact.postalAddress.street) {
-                    [response setObject:billingContact.postalAddress.street forKey:@"billingAddressStreet"];
-                }
-                
-                if (billingContact.postalAddress.city) {
-                    [response setObject:billingContact.postalAddress.city forKey:@"billingAddressCity"];
-                }
-                
-                if (billingContact.postalAddress.state) {
-                    [response setObject:billingContact.postalAddress.state forKey:@"billingAddressState"];
-                }
-                
-                
-                if (billingContact.postalAddress.postalCode) {
-                    [response setObject:billingContact.postalAddress.postalCode forKey:@"billingPostalCode"];
-                }
-                
-                if (billingContact.postalAddress.country) {
-                    [response setObject:billingContact.postalAddress.country forKey:@"billingCountry"];
-                }
-                
-                if (billingContact.postalAddress.ISOCountryCode) {
-                    [response setObject:billingContact.postalAddress.ISOCountryCode forKey:@"billingISOCountryCode"];
-                }
-                
+        if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 2, 0}]) {
+            if (billingContact.supplementarySubLocality) {
+                [response setObject:billingContact.supplementarySubLocality forKey:@"billingSupplementarySubLocality"];
             }
         }
         
-        PKContact *shippingContact = payment.shippingContact;
-        if (shippingContact) {
-            if (shippingContact.emailAddress) {
-                [response setObject:shippingContact.emailAddress forKey:@"shippingEmailAddress"];
+        if (billingContact.name) {
+            
+            if (billingContact.name.givenName) {
+                [response setObject:billingContact.name.givenName forKey:@"billingNameFirst"];
             }
             
-            if (shippingContact.name) {
-                
-                if (shippingContact.name.givenName) {
-                    [response setObject:shippingContact.name.givenName forKey:@"shippingNameFirst"];
-                }
-                
-                if (shippingContact.name.middleName) {
-                    [response setObject:shippingContact.name.middleName forKey:@"shippingNameMiddle"];
-                }
-                
-                if (shippingContact.name.familyName) {
-                    [response setObject:shippingContact.name.familyName forKey:@"shippingNameLast"];
-                }
-                
-            }
-            if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 2, 0}]) {
-                if (shippingContact.supplementarySubLocality) {
-                    [response setObject:shippingContact.supplementarySubLocality forKey:@"shippingSupplementarySubLocality"];
-                }
+            if (billingContact.name.middleName) {
+                [response setObject:billingContact.name.middleName forKey:@"billingNameMiddle"];
             }
             
-            if (shippingContact.postalAddress) {
-                
-                if (shippingContact.postalAddress.street) {
-                    [response setObject:shippingContact.postalAddress.street forKey:@"shippingAddressStreet"];
-                }
-                
-                if (shippingContact.postalAddress.city) {
-                    [response setObject:shippingContact.postalAddress.city forKey:@"shippingAddressCity"];
-                }
-                
-                if (shippingContact.postalAddress.state) {
-                    [response setObject:shippingContact.postalAddress.state forKey:@"shippingAddressState"];
-                }
-                
-                if (shippingContact.postalAddress.postalCode) {
-                    [response setObject:shippingContact.postalAddress.postalCode forKey:@"shippingPostalCode"];
-                }
-                
-                if (shippingContact.postalAddress.country) {
-                    [response setObject:shippingContact.postalAddress.country forKey:@"shippingCountry"];
-                }
-                
-                if (shippingContact.postalAddress.ISOCountryCode) {
-                    [response setObject:shippingContact.postalAddress.ISOCountryCode forKey:@"shippingISOCountryCode"];
-                }
-                
+            if (billingContact.name.familyName) {
+                [response setObject:billingContact.name.familyName forKey:@"billingNameLast"];
             }
+            
         }
         
-        
-    } else if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){8, 0, 0}]) {
-        
-        ABRecordRef billingAddress = payment.billingAddress;
-        if (billingAddress) {
-            //[self applyABRecordShippingAddress:billingAddress forDictionary:response];
+        if (billingContact.postalAddress) {
+            
+            if (billingContact.postalAddress.street) {
+                [response setObject:billingContact.postalAddress.street forKey:@"billingAddressStreet"];
+            }
+            
+            if (billingContact.postalAddress.city) {
+                [response setObject:billingContact.postalAddress.city forKey:@"billingAddressCity"];
+            }
+            
+            if (billingContact.postalAddress.state) {
+                [response setObject:billingContact.postalAddress.state forKey:@"billingAddressState"];
+            }
+            
+            
+            if (billingContact.postalAddress.postalCode) {
+                [response setObject:billingContact.postalAddress.postalCode forKey:@"billingPostalCode"];
+            }
+            
+            if (billingContact.postalAddress.country) {
+                [response setObject:billingContact.postalAddress.country forKey:@"billingCountry"];
+            }
+            
+            if (billingContact.postalAddress.ISOCountryCode) {
+                [response setObject:billingContact.postalAddress.ISOCountryCode forKey:@"billingISOCountryCode"];
+            }
+            
         }
-        
-        ABRecordRef shippingAddress = payment.shippingAddress;
-        if (shippingAddress) {
-            [self applyABRecordShippingAddress:shippingAddress forDictionary:response];
-        }
-        
     }
     
+    PKContact *shippingContact = payment.shippingContact;
+    if (shippingContact) {
+        if (shippingContact.emailAddress) {
+            [response setObject:shippingContact.emailAddress forKey:@"shippingEmailAddress"];
+        }
+        
+        if (shippingContact.name) {
+            
+            if (shippingContact.name.givenName) {
+                [response setObject:shippingContact.name.givenName forKey:@"shippingNameFirst"];
+            }
+            
+            if (shippingContact.name.middleName) {
+                [response setObject:shippingContact.name.middleName forKey:@"shippingNameMiddle"];
+            }
+            
+            if (shippingContact.name.familyName) {
+                [response setObject:shippingContact.name.familyName forKey:@"shippingNameLast"];
+            }
+            
+        }
+        if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 2, 0}]) {
+            if (shippingContact.supplementarySubLocality) {
+                [response setObject:shippingContact.supplementarySubLocality forKey:@"shippingSupplementarySubLocality"];
+            }
+        }
+        
+        if (shippingContact.postalAddress) {
+            
+            if (shippingContact.postalAddress.street) {
+                [response setObject:shippingContact.postalAddress.street forKey:@"shippingAddressStreet"];
+            }
+            
+            if (shippingContact.postalAddress.city) {
+                [response setObject:shippingContact.postalAddress.city forKey:@"shippingAddressCity"];
+            }
+            
+            if (shippingContact.postalAddress.state) {
+                [response setObject:shippingContact.postalAddress.state forKey:@"shippingAddressState"];
+            }
+            
+            if (shippingContact.postalAddress.postalCode) {
+                [response setObject:shippingContact.postalAddress.postalCode forKey:@"shippingPostalCode"];
+            }
+            
+            if (shippingContact.postalAddress.country) {
+                [response setObject:shippingContact.postalAddress.country forKey:@"shippingCountry"];
+            }
+            
+            if (shippingContact.postalAddress.ISOCountryCode) {
+                [response setObject:shippingContact.postalAddress.ISOCountryCode forKey:@"shippingISOCountryCode"];
+            }
+            
+        }
+    }
     
     return response;
 }

--- a/src/ios/CDVApplePay.m
+++ b/src/ios/CDVApplePay.m
@@ -85,46 +85,46 @@
 
 - (PKAddressField)billingAddressRequirementFromArguments:(NSArray *)arguments
 {
-    NSString *billingAddressRequirement = [[arguments objectAtIndex:0] objectForKey:@"billingAddressRequirement"];
+    NSArray *billingAddressRequirement = [[arguments objectAtIndex:0] objectForKey:@"billingAddressRequirement"];
+    PKAddressField requiredFields = PKAddressFieldNone;
     
-    if ([billingAddressRequirement isEqualToString:@"none"]) {
-        return PKAddressFieldNone;
-    } else if ([billingAddressRequirement isEqualToString:@"all"]) {
-        return PKAddressFieldAll;
-    } else if ([billingAddressRequirement isEqualToString:@"postcode"]) {
-        return PKAddressFieldPostalAddress;
-    } else if ([billingAddressRequirement isEqualToString:@"name"]) {
-        return PKAddressFieldName;
-    } else if ([billingAddressRequirement isEqualToString:@"email"]) {
-        return PKAddressFieldEmail;
-    } else if ([billingAddressRequirement isEqualToString:@"phone"]) {
-        return PKAddressFieldPhone;
+    for (id requirement in billingAddressRequirement) {
+        if ([requirement isEqualToString:@"all"]) {
+            requiredFields = requiredFields | PKAddressFieldAll;
+        } else if ([requirement isEqualToString:@"postcode"]) {
+            requiredFields = requiredFields | PKAddressFieldPostalAddress;
+        } else if ([requirement isEqualToString:@"name"]) {
+            requiredFields = requiredFields | PKAddressFieldName;
+        } else if ([requirement isEqualToString:@"email"]) {
+            requiredFields = requiredFields | PKAddressFieldEmail;
+        } else if ([requirement isEqualToString:@"phone"]) {
+            requiredFields = requiredFields | PKAddressFieldPhone;
+        }
     }
     
-    
-    return PKAddressFieldNone;
+    return requiredFields;
 }
 
 - (PKAddressField)shippingAddressRequirementFromArguments:(NSArray *)arguments
 {
-    NSString *shippingAddressRequirement = [[arguments objectAtIndex:0] objectForKey:@"shippingAddressRequirement"];
+    NSArray *shippingAddressRequirements = [[arguments objectAtIndex:0] objectForKey:@"shippingAddressRequirement"];
+    PKAddressField requiredFields = PKAddressFieldNone;
     
-    if ([shippingAddressRequirement isEqualToString:@"none"]) {
-        return PKAddressFieldNone;
-    } else if ([shippingAddressRequirement isEqualToString:@"all"]) {
-        return PKAddressFieldAll;
-    } else if ([shippingAddressRequirement isEqualToString:@"postcode"]) {
-        return PKAddressFieldPostalAddress;
-    } else if ([shippingAddressRequirement isEqualToString:@"name"]) {
-        return PKAddressFieldName;
-    } else if ([shippingAddressRequirement isEqualToString:@"email"]) {
-        return PKAddressFieldEmail;
-    } else if ([shippingAddressRequirement isEqualToString:@"phone"]) {
-        return PKAddressFieldPhone;
+    for (id requirement in shippingAddressRequirements) {
+        if ([requirement isEqualToString:@"all"]) {
+            requiredFields = requiredFields | PKAddressFieldAll;
+        } else if ([requirement isEqualToString:@"postcode"]) {
+            requiredFields = requiredFields | PKAddressFieldPostalAddress;
+        } else if ([requirement isEqualToString:@"name"]) {
+            requiredFields = requiredFields | PKAddressFieldName;
+        } else if ([requirement isEqualToString:@"email"]) {
+            requiredFields = requiredFields | PKAddressFieldEmail;
+        } else if ([requirement isEqualToString:@"phone"]) {
+            requiredFields = requiredFields | PKAddressFieldPhone;
+        }
     }
     
-    
-    return PKAddressFieldNone;
+    return requiredFields;
 }
 
 - (NSArray *)itemsFromArguments:(NSArray *)arguments
@@ -355,6 +355,10 @@
     if (shippingContact) {
         if (shippingContact.emailAddress) {
             [response setObject:shippingContact.emailAddress forKey:@"shippingEmailAddress"];
+        }
+        
+        if (shippingContact.phoneNumber) {
+            [response setObject:shippingContact.phoneNumber.stringValue forKey:@"shippingPhoneNumber"];
         }
         
         if (shippingContact.name) {

--- a/src/ios/CDVApplePay.m
+++ b/src/ios/CDVApplePay.m
@@ -8,16 +8,14 @@
 
 - (void)pluginInitialize
 {
-
+    
     // Set these to the payment cards accepted.
     // They will nearly always be the same.
     supportedPaymentNetworks = @[PKPaymentNetworkVisa, PKPaymentNetworkMasterCard, PKPaymentNetworkAmex];
-
+    
     // Set the capabilities that your merchant supports
     // Adyen for example, only supports the 3DS one.
     merchantCapabilities = PKMerchantCapability3DS;// PKMerchantCapabilityEMV;
-
-
 }
 
 - (NSMutableDictionary*)applyABRecordBillingAddress:(ABRecordRef)address forDictionary:(NSMutableDictionary*)response {
@@ -28,10 +26,10 @@
     NSString *country;
     NSString *countryCode;
     //NSString *emailAddress;
-
-
+    
+    
     // TODO: Validate email
-
+    
     //    if (shippingContact.emailAddress) {
     //        [response setObject:shippingContact.emailAddress forKey:@"billingEmailAddress"];
     //    }
@@ -39,51 +37,51 @@
     //    if (shippingContact.supplementarySubLocality) {
     //        [response setObject:shippingContact.supplementarySubLocality forKey:@"billingSupplementarySubLocality"];
     //    }
-
-
+    
+    
     //emailAddress = (__bridge NSString *)(CFDictionaryGetValue(address, kABPersonEmailProperty));
-
-
+    
+    
     ABMultiValueRef addressRecord = ABRecordCopyValue(address, kABPersonAddressProperty);
     if (ABMultiValueGetCount(addressRecord) > 0) {
         CFDictionaryRef dict = ABMultiValueCopyValueAtIndex(addressRecord, 0);
-
+        
         address1 = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressStreetKey));
         city = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressCityKey));
         postcode = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressZIPKey));
         state = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressStateKey));
         country = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressCountryKey));
         countryCode = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressCountryCodeKey));
-
-
+        
+        
         if (address1) {
             [response setObject:address1 forKey:@"billingAddressStreet"];
         }
-
+        
         if (city) {
             [response setObject:city forKey:@"billingAddressCity"];
         }
-
+        
         if (postcode) {
             [response setObject:postcode forKey:@"billingPostalCode"];
         }
-
+        
         if (state) {
             [response setObject:state forKey:@"billingAddressState"];
         }
-
+        
         if (country) {
             [response setObject:country forKey:@"billingCountry"];
         }
-
+        
         if (countryCode) {
             [response setObject:countryCode forKey:@"billingISOCountryCode"];
         }
-
+        
     }
-
+    
     // TODO: Valdidate address
-
+    
     //    BOOL valid = (address1 && ![address1 isEqualToString:@""] &&
     //                  city && ![city isEqualToString:@""] &&
     //                  postcode && ![postcode isEqualToString:@""] &&
@@ -103,10 +101,10 @@
     NSString *country;
     NSString *countryCode;
     //NSString *emailAddress;
-
-
+    
+    
     // TODO: Validate email
-
+    
     //    if (shippingContact.emailAddress) {
     //        [response setObject:shippingContact.emailAddress forKey:@"shippingEmailAddress"];
     //    }
@@ -114,51 +112,51 @@
     //    if (shippingContact.supplementarySubLocality) {
     //        [response setObject:shippingContact.supplementarySubLocality forKey:@"shippingSupplementarySubLocality"];
     //    }
-
-
+    
+    
     //emailAddress = (__bridge NSString *)(CFDictionaryGetValue(address, kABPersonEmailProperty));
-
-
+    
+    
     ABMultiValueRef addressRecord = ABRecordCopyValue(address, kABPersonAddressProperty);
     if (ABMultiValueGetCount(addressRecord) > 0) {
         CFDictionaryRef dict = ABMultiValueCopyValueAtIndex(addressRecord, 0);
-
+        
         address1 = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressStreetKey));
         city = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressCityKey));
         postcode = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressZIPKey));
         state = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressStateKey));
         country = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressCountryKey));
         countryCode = (__bridge NSString *)(CFDictionaryGetValue(dict, kABPersonAddressCountryCodeKey));
-
-
+        
+        
         if (address1) {
             [response setObject:address1 forKey:@"shippingAddressStreet"];
         }
-
+        
         if (city) {
             [response setObject:city forKey:@"shippingAddressCity"];
         }
-
+        
         if (postcode) {
             [response setObject:postcode forKey:@"shippingPostalCode"];
         }
-
+        
         if (state) {
             [response setObject:state forKey:@"shippingAddressState"];
         }
-
+        
         if (country) {
             [response setObject:country forKey:@"shippingCountry"];
         }
-
+        
         if (countryCode) {
             [response setObject:countryCode forKey:@"shippingISOCountryCode"];
         }
-
+        
     }
-
+    
     // TODO: Valdidate address
-
+    
     //    BOOL valid = (address1 && ![address1 isEqualToString:@""] &&
     //                  city && ![city isEqualToString:@""] &&
     //                  postcode && ![postcode isEqualToString:@""] &&
@@ -231,7 +229,7 @@
 - (PKShippingType)shippingTypeFromArguments:(NSArray *)arguments
 {
     NSString *shippingType = [[arguments objectAtIndex:0] objectForKey:@"shippingType"];
-
+    
     if ([shippingType isEqualToString:@"shipping"]) {
         return PKShippingTypeShipping;
     } else if ([shippingType isEqualToString:@"delivery"]) {
@@ -241,15 +239,15 @@
     } else if ([shippingType isEqualToString:@"service"]) {
         return PKShippingTypeServicePickup;
     }
-
-
+    
+    
     return PKShippingTypeShipping;
 }
 
 - (PKAddressField)billingAddressRequirementFromArguments:(NSArray *)arguments
 {
     NSString *billingAddressRequirement = [[arguments objectAtIndex:0] objectForKey:@"billingAddressRequirement"];
-
+    
     if ([billingAddressRequirement isEqualToString:@"none"]) {
         return PKAddressFieldNone;
     } else if ([billingAddressRequirement isEqualToString:@"all"]) {
@@ -263,15 +261,15 @@
     } else if ([billingAddressRequirement isEqualToString:@"phone"]) {
         return PKAddressFieldPhone;
     }
-
-
+    
+    
     return PKAddressFieldNone;
 }
 
 - (PKAddressField)shippingAddressRequirementFromArguments:(NSArray *)arguments
 {
     NSString *shippingAddressRequirement = [[arguments objectAtIndex:0] objectForKey:@"shippingAddressRequirement"];
-
+    
     if ([shippingAddressRequirement isEqualToString:@"none"]) {
         return PKAddressFieldNone;
     } else if ([shippingAddressRequirement isEqualToString:@"all"]) {
@@ -285,57 +283,57 @@
     } else if ([shippingAddressRequirement isEqualToString:@"phone"]) {
         return PKAddressFieldPhone;
     }
-
-
+    
+    
     return PKAddressFieldNone;
 }
 
 - (NSArray *)itemsFromArguments:(NSArray *)arguments
 {
     NSArray *itemDescriptions = [[arguments objectAtIndex:0] objectForKey:@"items"];
-
+    
     NSMutableArray *items = [[NSMutableArray alloc] init];
-
+    
     for (NSDictionary *item in itemDescriptions) {
-
+        
         NSString *label = [item objectForKey:@"label"];
-
+        
         NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithDecimal:[[item objectForKey:@"amount"] decimalValue]];
-
+        
         PKPaymentSummaryItem *newItem = [PKPaymentSummaryItem summaryItemWithLabel:label amount:amount];
-
+        
         [items addObject:newItem];
     }
-
+    
     return items;
 }
 
 - (NSArray *)shippingMethodsFromArguments:(NSArray *)arguments
 {
     NSArray *shippingDescriptions = [[arguments objectAtIndex:0] objectForKey:@"shippingMethods"];
-
+    
     NSMutableArray *shippingMethods = [[NSMutableArray alloc] init];
-
-
+    
+    
     for (NSDictionary *desc in shippingDescriptions) {
-
+        
         NSString *identifier = [desc objectForKey:@"identifier"];
         NSString *detail = [desc objectForKey:@"detail"];
         NSString *label = [desc objectForKey:@"label"];
-
+        
         NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithDecimal:[[desc objectForKey:@"amount"] decimalValue]];
-
+        
         PKPaymentSummaryItem *newMethod = [self shippingMethodWithIdentifier:identifier detail:detail label:label amount:amount];
-
+        
         [shippingMethods addObject:newMethod];
     }
-
+    
     return shippingMethods;
 }
 
 - (PKPaymentAuthorizationStatus)paymentAuthorizationStatusFromArgument:(NSString *)paymentAuthorizationStatus
 {
-
+    
     if ([paymentAuthorizationStatus isEqualToString:@"success"]) {
         return PKPaymentAuthorizationStatusSuccess;
     } else if ([paymentAuthorizationStatus isEqualToString:@"failure"]) {
@@ -353,47 +351,47 @@
     } else if ([paymentAuthorizationStatus isEqualToString:@"locked-pin"]) {
         return PKPaymentAuthorizationStatusPINLockout;
     }
-
+    
     return PKPaymentAuthorizationStatusFailure;
 }
 
 - (void)completeLastTransaction:(CDVInvokedUrlCommand*)command
 {
     if (self.paymentAuthorizationBlock) {
-
+        
         NSString *paymentAuthorizationStatusString = [command.arguments objectAtIndex:0];
         NSLog(@"ApplePay completeLastTransaction == %@", paymentAuthorizationStatusString);
-
+        
         PKPaymentAuthorizationStatus paymentAuthorizationStatus = [self paymentAuthorizationStatusFromArgument:paymentAuthorizationStatusString];
         self.paymentAuthorizationBlock(paymentAuthorizationStatus);
-
+        
         CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @"Payment status applied."];
         [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
-
+        
     }
 }
 
 - (void)makePaymentRequest:(CDVInvokedUrlCommand*)command
 {
     self.paymentCallbackId = command.callbackId;
-
+    
     NSLog(@"ApplePay canMakePayments == %s", [PKPaymentAuthorizationViewController canMakePayments]? "true" : "false");
     if ([PKPaymentAuthorizationViewController canMakePayments] == NO) {
         CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"This device cannot make payments."];
         [self.commandDelegate sendPluginResult:result callbackId:self.paymentCallbackId];
         return;
     }
-
+    
     // reset any lingering callbacks, incase the previous payment failed.
     self.paymentAuthorizationBlock = nil;
-
+    
     PKPaymentRequest *request = [PKPaymentRequest new];
-
+    
     // Different version of iOS support different networks, (ie Discover card is iOS9+; not part of my project, so ignoring).
     request.supportedNetworks = supportedPaymentNetworks;
-
+    
     request.merchantCapabilities = merchantCapabilities;
-
+    
     // All this data is loaded from the Cordova object passed in. See documentation.
     [request setCurrencyCode:[self currencyCodeFromArguments:command.arguments]];
     [request setCountryCode:[self countryCodeFromArguments:command.arguments]];
@@ -403,177 +401,193 @@
     [request setShippingType:[self shippingTypeFromArguments:command.arguments]];
     [request setShippingMethods:[self shippingMethodsFromArguments:command.arguments]];
     [request setPaymentSummaryItems:[self itemsFromArguments:command.arguments]];
-
+    self.shippingMethods = [self shippingMethodsFromArguments:command.arguments];
+    self.summaryItems = [self itemsFromArguments:command.arguments];
+    
     NSLog(@"ApplePay request == %@", request);
-
+    
     PKPaymentAuthorizationViewController *authVC = [[PKPaymentAuthorizationViewController alloc] initWithPaymentRequest:request];
-
+    
     authVC.delegate = self;
-
+    
     if (authVC == nil) {
         CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"PKPaymentAuthorizationViewController was nil."];
         [self.commandDelegate sendPluginResult:result callbackId:self.paymentCallbackId];
         return;
     }
-
+    
     [self.viewController presentViewController:authVC animated:YES completion:nil];
+}
+
+- (void)updateItemsAndShippingMethods:(CDVInvokedUrlCommand*)command
+{
+    if (self.updateItemsAndShippingMethodsBlock != nil) {
+        self.shippingMethods = [self shippingMethodsFromArguments:command.arguments];
+        self.summaryItems = [self itemsFromArguments:command.arguments];
+        self.updateItemsAndShippingMethodsBlock(PKPaymentAuthorizationStatusSuccess, self.shippingMethods, self.summaryItems);
+        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @"Updated List Info"];
+        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+    } else {
+        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"Did you make a payment request?"];
+        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+    }
 }
 
 - (void)paymentAuthorizationViewControllerDidFinish:(PKPaymentAuthorizationViewController *)controller
 {
     [self.viewController dismissViewControllerAnimated:YES completion:nil];
-
+    
     CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"Payment not completed."];
     [self.commandDelegate sendPluginResult:result callbackId:self.paymentCallbackId];
 }
 
 - (NSDictionary*) formatPaymentForApplication:(PKPayment *)payment {
     NSString *paymentData = [payment.token.paymentData base64EncodedStringWithOptions:0];
-
+    
     //    NSDictionary *response = @{
     //                               @"paymentData":paymentData,
     //                               @"transactionIdentifier":payment.token.transactionIdentifier
     //                               };
-
+    
     NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
-
+    
     [response setObject:paymentData  forKey:@"paymentData"];
     [response setObject:payment.token.transactionIdentifier  forKey:@"transactionIdentifier"];
-
+    
     // Different version of iOS present the billing/shipping addresses in different ways. Pain.
     if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 0, 0}]) {
-
-
+        
+        
         PKContact *billingContact = payment.billingContact;
         if (billingContact) {
             if (billingContact.emailAddress) {
                 [response setObject:billingContact.emailAddress forKey:@"billingEmailAddress"];
             }
-
+            
             if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 2, 0}]) {
                 if (billingContact.supplementarySubLocality) {
                     [response setObject:billingContact.supplementarySubLocality forKey:@"billingSupplementarySubLocality"];
                 }
             }
-
+            
             if (billingContact.name) {
-
+                
                 if (billingContact.name.givenName) {
                     [response setObject:billingContact.name.givenName forKey:@"billingNameFirst"];
                 }
-
+                
                 if (billingContact.name.middleName) {
                     [response setObject:billingContact.name.middleName forKey:@"billingNameMiddle"];
                 }
-
+                
                 if (billingContact.name.familyName) {
                     [response setObject:billingContact.name.familyName forKey:@"billingNameLast"];
                 }
-
+                
             }
-
+            
             if (billingContact.postalAddress) {
-
+                
                 if (billingContact.postalAddress.street) {
                     [response setObject:billingContact.postalAddress.street forKey:@"billingAddressStreet"];
                 }
-
+                
                 if (billingContact.postalAddress.city) {
                     [response setObject:billingContact.postalAddress.city forKey:@"billingAddressCity"];
                 }
-
+                
                 if (billingContact.postalAddress.state) {
                     [response setObject:billingContact.postalAddress.state forKey:@"billingAddressState"];
                 }
-
-
+                
+                
                 if (billingContact.postalAddress.postalCode) {
                     [response setObject:billingContact.postalAddress.postalCode forKey:@"billingPostalCode"];
                 }
-
+                
                 if (billingContact.postalAddress.country) {
                     [response setObject:billingContact.postalAddress.country forKey:@"billingCountry"];
                 }
-
+                
                 if (billingContact.postalAddress.ISOCountryCode) {
                     [response setObject:billingContact.postalAddress.ISOCountryCode forKey:@"billingISOCountryCode"];
                 }
-
+                
             }
         }
-
+        
         PKContact *shippingContact = payment.shippingContact;
         if (shippingContact) {
             if (shippingContact.emailAddress) {
                 [response setObject:shippingContact.emailAddress forKey:@"shippingEmailAddress"];
             }
-
+            
             if (shippingContact.name) {
-
+                
                 if (shippingContact.name.givenName) {
                     [response setObject:shippingContact.name.givenName forKey:@"shippingNameFirst"];
                 }
-
+                
                 if (shippingContact.name.middleName) {
                     [response setObject:shippingContact.name.middleName forKey:@"shippingNameMiddle"];
                 }
-
+                
                 if (shippingContact.name.familyName) {
                     [response setObject:shippingContact.name.familyName forKey:@"shippingNameLast"];
                 }
-
+                
             }
             if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 2, 0}]) {
                 if (shippingContact.supplementarySubLocality) {
                     [response setObject:shippingContact.supplementarySubLocality forKey:@"shippingSupplementarySubLocality"];
                 }
             }
-
+            
             if (shippingContact.postalAddress) {
-
+                
                 if (shippingContact.postalAddress.street) {
                     [response setObject:shippingContact.postalAddress.street forKey:@"shippingAddressStreet"];
                 }
-
+                
                 if (shippingContact.postalAddress.city) {
                     [response setObject:shippingContact.postalAddress.city forKey:@"shippingAddressCity"];
                 }
-
+                
                 if (shippingContact.postalAddress.state) {
                     [response setObject:shippingContact.postalAddress.state forKey:@"shippingAddressState"];
                 }
-
+                
                 if (shippingContact.postalAddress.postalCode) {
                     [response setObject:shippingContact.postalAddress.postalCode forKey:@"shippingPostalCode"];
                 }
-
+                
                 if (shippingContact.postalAddress.country) {
                     [response setObject:shippingContact.postalAddress.country forKey:@"shippingCountry"];
                 }
-
+                
                 if (shippingContact.postalAddress.ISOCountryCode) {
                     [response setObject:shippingContact.postalAddress.ISOCountryCode forKey:@"shippingISOCountryCode"];
                 }
-
+                
             }
         }
-
-
+        
+        
     } else if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){8, 0, 0}]) {
-
+        
         ABRecordRef billingAddress = payment.billingAddress;
         if (billingAddress) {
             //[self applyABRecordShippingAddress:billingAddress forDictionary:response];
         }
-
+        
         ABRecordRef shippingAddress = payment.shippingAddress;
         if (shippingAddress) {
             [self applyABRecordShippingAddress:shippingAddress forDictionary:response];
         }
-
+        
     }
-
-
+    
+    
     return response;
 }
 
@@ -582,16 +596,64 @@
                                 completion:(void (^)(PKPaymentAuthorizationStatus status))completion
 {
     NSLog(@"CDVApplePay: didAuthorizePayment");
-
+    
     if (completion) {
         self.paymentAuthorizationBlock = completion;
     }
     NSDictionary* response = [self formatPaymentForApplication:payment];
-
+    
     CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:response];
     [self.commandDelegate sendPluginResult:result callbackId:self.paymentCallbackId];
 }
 
+- (void)paymentAuthorizationViewController:(PKPaymentAuthorizationViewController *)controller
+                  didSelectShippingContact:(PKContact *)contact
+                                completion:(void (^)(PKPaymentAuthorizationStatus status, NSArray<PKShippingMethod *> *shippingMethods, NSArray<PKPaymentSummaryItem *> *summaryItems))completion
+{
+    if (self.shippingContactSelectionListenerCallbackId) {
+        NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
+        if (contact.postalAddress) {
+            if (contact.postalAddress.city) {
+                [response setObject:contact.postalAddress.city forKey:@"shippingAddressCity"];
+            }
+            
+            if (contact.postalAddress.state) {
+                [response setObject:contact.postalAddress.state forKey:@"shippingAddressState"];
+            }
+            
+            if (contact.postalAddress.postalCode) {
+                [response setObject:contact.postalAddress.postalCode forKey:@"shippingPostalCode"];
+            }
+            
+            if (contact.postalAddress.ISOCountryCode) {
+                [response setObject:[contact.postalAddress.ISOCountryCode uppercaseString] forKey:@"shippingISOCountryCode"];
+            }
+        }
+        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:response];
+        [result setKeepCallbackAsBool:YES];
+        [self.commandDelegate sendPluginResult:result callbackId:self.shippingContactSelectionListenerCallbackId];
+        self.updateItemsAndShippingMethodsBlock = completion;
+    } else {
+        completion(PKPaymentAuthorizationStatusSuccess, self.shippingMethods, self.summaryItems);
+    }
+}
+
+- (void)startListeningForShippingContactSelection:(CDVInvokedUrlCommand *)command
+{
+    self.shippingContactSelectionListenerCallbackId = command.callbackId;
+}
+
+- (void)stopListeningForShippingContactSelection:(CDVInvokedUrlCommand *)command
+{
+    if (self.shippingContactSelectionListenerCallbackId) {
+        self.shippingContactSelectionListenerCallbackId = nil;
+        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:YES];
+        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+    } else {
+        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsBool:NO];
+        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+    }
+}
 
 - (PKShippingMethod *)shippingMethodWithIdentifier:(NSString *)idenfifier detail:(NSString *)detail label:(NSString *)label amount:(NSDecimalNumber *)amount
 {
@@ -600,7 +662,7 @@
     shippingMethod.detail = detail;
     shippingMethod.amount = amount;
     shippingMethod.label = label;
-
+    
     return shippingMethod;
 }
 

--- a/www/applepay.js
+++ b/www/applepay.js
@@ -34,6 +34,12 @@ var ApplePay = {
      * @returns {Promise}
      */
     makePaymentRequest: function(order, successCallback, errorCallback) {
+        if (!Array.isArray(order.billingAddressRequirement)) {
+            order.billingAddressRequirement = [order.billingAddressRequirement];
+        }
+        if (!Array.isArray(order.shippingAddressRequirement)) {
+            order.shippingAddressRequirement = [order.shippingAddressRequirement];
+        }
         return new Promise(function(resolve, reject) {
             exec(function(message) {
                 executeCallback(successCallback, message);

--- a/www/applepay.js
+++ b/www/applepay.js
@@ -56,7 +56,7 @@ var ApplePay = {
      * @param {Function} [errorCallback] - Optional error callback, receives message object.
      * @returns {void}
      */
-    startListeningForShippingContactSelection(successCallback, errorCallback) {
+    startListeningForShippingContactSelection: function(successCallback, errorCallback) {
         exec(function(message) {
             executeCallback(successCallback, message);
         }, function(message) {
@@ -70,7 +70,7 @@ var ApplePay = {
      * @param {Function} [errorCallback] - Optional error callback, receives message object.
      * @return {Promise}
      */
-    stopListeningForShippingContactSelection(successCallback, errorCallback) {
+    stopListeningForShippingContactSelection: function(successCallback, errorCallback) {
         return new Promise(function(resolve, reject) {
             exec(function(message) {
                 executeCallback(successCallback, message);

--- a/www/applepay.js
+++ b/www/applepay.js
@@ -9,7 +9,6 @@ var executeCallback = function(callback, message) {
 };
 
 var ApplePay = {
-
     /**
      * Determines if the current device supports Apple Pay and has a supported card installed.
      * @param {Function} [successCallback] - Optional success callback, recieves message object.
@@ -26,7 +25,6 @@ var ApplePay = {
                 reject(message);
             }, 'ApplePay', 'canMakePayments', []);
         });
-
     },
 
     /**
@@ -36,7 +34,6 @@ var ApplePay = {
      * @returns {Promise}
      */
     makePaymentRequest: function(order, successCallback, errorCallback) {
-
         return new Promise(function(resolve, reject) {
             exec(function(message) {
                 executeCallback(successCallback, message);
@@ -46,7 +43,65 @@ var ApplePay = {
                 reject(message);
             }, 'ApplePay', 'makePaymentRequest', [order]);
         });
+    },
 
+    /**
+     * Starts listening for shipping contact selection changes
+     * Any time the user selects shipping contact, this callback will fire.
+     * You *must* call `updateItemsAndShippingMethods` in response or else the
+     * user will not be able to process payment.
+     * @param {Function} [successCallback] - Required success callback
+     *  Fires whenever the user updates their shipping contact selection on the
+     *  pay sheet (may also fire initially if the user has default information).
+     * @param {Function} [errorCallback] - Optional error callback, receives message object.
+     * @returns {void}
+     */
+    startListeningForShippingContactSelection(successCallback, errorCallback) {
+        exec(function(message) {
+            executeCallback(successCallback, message);
+        }, function(message) {
+            executeCallback(errorCallback, message);
+        }, 'ApplePay', 'startListeningForShippingContactSelection');
+    },
+
+    /**
+     * Stops listening for shipping contact selection changes
+     * @param {Function} [successCallback] - Optional success callback
+     * @param {Function} [errorCallback] - Optional error callback, receives message object.
+     * @return {Promise}
+     */
+    stopListeningForShippingContactSelection(successCallback, errorCallback) {
+        return new Promise(function(resolve, reject) {
+            exec(function(message) {
+                executeCallback(successCallback, message);
+                resolve(message);
+            }, function(message) {
+                executeCallback(errorCallback, message);
+                reject(message);
+            }, 'ApplePay', 'stopListeningForShippingContactSelection');
+        });
+    },
+
+    /**
+     * Update the list of pay sheet items and shipping methods in response to
+     * a shipping contact selection event. This *must* be called in response to
+     * any shipping contact selection event or else the user will not be able
+     * to complete a transaction on the pay sheet.
+     * @param {Object} including `items` and `shippingMethods` properties.
+     * @param {Function} [successCallback] - Optional success callback, receives message object.
+     * @param {Function} [errorCallback] - Optional error callback, receives message object.
+     * @returns {Promise}
+     */
+    updateItemsAndShippingMethods: function(list, successCallback, errorCallback) {
+        return new Promise(function(resolve, reject) {
+            exec(function(message) {
+                executeCallback(successCallback, message);
+                resolve(message);
+            }, function(message) {
+                executeCallback(errorCallback, message);
+                reject(message);
+            }, 'ApplePay', 'updateItemsAndShippingMethods', [list]);
+        });
     },
 
     /**
@@ -57,7 +112,6 @@ var ApplePay = {
      * @returns {Promise}
      */
     completeLastTransaction: function(status, successCallback, errorCallback) {
-
         return new Promise(function(resolve, reject) {
             exec(function(message) {
                 executeCallback(successCallback, message);
@@ -67,9 +121,7 @@ var ApplePay = {
                 reject(message);
             }, 'ApplePay', 'completeLastTransaction', [status]);
         });
-
     }
-
 };
 
 module.exports = ApplePay;


### PR DESCRIPTION
Suggested update to the plugin to add the following:

* Removing support for iOS 8 (see #13 as well). As iOS 11 will soon be out, I think iOS 9 is a fine minimum version to support.
* Adding methods to start and stop listening to shipping contact selection on the pay sheet. This also requires updating items / shippingMethods in response to contact selection.
* Allow users to specify multiple shipping / billing requirements at once so you can require, `name` and `phone`, for example.
* Send back shipping contact phone number after completing a payment request. This wasn't being done before.