### PR TITLE
Make supportedNetworks and merchantCapabilities configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ ApplePay.canMakePayments().then((message) => {
   // 'This device cannot make payments.''
   // 'This device can make payments but has no supported cards'
 });
+```
 
+Detects if the current device supports Apple Pay and has any cards of `supportedNetworks` and `merchantCapabilities`.
+```ecmascript 6
 ApplePay.canMakePayments({
   // supportedNetworks should not be an empty array. The supported networks currently are: amex, discover, masterCard, visa
   supportedNetworks: ['visa', 'amex'],

--- a/README.md
+++ b/README.md
@@ -54,17 +54,30 @@ The methods available all return promises, or accept success and error callbacks
 ## ApplePay.canMakePayments
 Detects if the current device supports Apple Pay and has any *capable* cards registered.
 
-```
-ApplePay.canMakePayments()
-    .then((message) => {
-        // Apple Pay is enabled and a supported card is setup. Expect:
-        // 'This device can make payments and has a supported card'
-    })
-    .catch((message) => {
-        // There is an issue, examine the message to see the details, will be:
-        // 'This device cannot make payments.''
-        // 'This device can make payments but has no supported cards'
-    });
+```ecmascript 6
+ApplePay.canMakePayments().then((message) => {
+  // Apple Pay is enabled. Expect:
+  // 'This device can make payments.'
+}).catch((message) => {
+  // There is an issue, examine the message to see the details, will be:
+  // 'This device cannot make payments.''
+  // 'This device can make payments but has no supported cards'
+});
+
+ApplePay.canMakePayments({
+  // supportedNetworks should not be an empty array. The supported networks currently are: amex, discover, masterCard, visa
+  supportedNetworks: ['visa', 'amex'],
+  
+  // when merchantCapabilities is passed in, supportedNetworks must also be provided. Valid values: 3ds, debit, credit, emv
+  merchantCapabilities: ['3ds', 'debit', 'credit']
+}).then((message) => {
+  // Apple Pay is enabled and a supported card is setup. Expect:
+  // 'This device can make payments and has a supported card'
+}).catch((message) => {
+  // There is an issue, examine the message to see the details, will be:
+  // 'This device cannot make payments.''
+  // 'This device can make payments but has no supported cards'
+});
 ```
 
 If in your `catch` you get the message `This device can make payments but has no supported cards` - you can decide if you want to handle this by showing the 'Setup Apple Pay' buttons instead of the
@@ -170,6 +183,8 @@ ApplePay.makePaymentRequest(
                   amount: 6.99
               }
           ],
+          supportedNetworks: ['visa', 'masterCard', 'discover'],
+          merchantCapabilities: ['3ds', 'debit', 'credit'],          
           merchantIdentifier: 'merchant.apple.test',
           currencyCode: 'GBP',
           countryCode: 'GB',
@@ -287,8 +302,7 @@ catch (err) {
 ```
 
 ## Limitations and TODOs
-* *Supported Payment Networks hard coded* (Visa, Mastercard, American Express) - This should be updated to be passed along in the order, but is rarely changed and trivial to alter in code.
-* *Merchant Capabilities hard coded (3DS)* - This should be updated to be passed along in the order, but is rarely changed and trivial to alter in code.
+* *Support more networks* - currently only Visa, MasterCard, American Express and Discover are accepted as config options.
 * *Event binds for delivery method selector* - An event can be raised when the customer
 selects different delivery options, so the merchant can update the delivery charges.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-applepay",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description":
   "An adapted Cordova plugin to provide Apple Pay functionality.",
   "main": "www/applepay.js",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "cordova-plugin-applepay",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description":
-    "An adapted Cordova plugin to provide Apple Pay functionality.",
+  "An adapted Cordova plugin to provide Apple Pay functionality.",
   "main": "www/applepay.js",
   "scripts": {},
   "repository": {
@@ -15,7 +15,10 @@
     "email": "sam@samkelleher.com",
     "url": "https://samkelleher.com/"
   },
-  "contributors": ["Andrew Crites <acjcrites@gmail.com>"],
+  "contributors": [
+    "Andrew Crites <acjcrites@gmail.com>",
+    "Balazs Sarvari <balazs.sarvari@gmail.com>"
+  ],
   "license": "Apache-2.0",
   "homepage": "https://github.com/samkelleher/cordova-plugin-applepay"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="cordova-plugin-applepay"
-      version="3.0.0">
+      version="4.0.0">
 
     <name>Apple Pay</name>
     <description>Implements Apple Pay.</description>

--- a/src/ios/CDVApplePay.h
+++ b/src/ios/CDVApplePay.h
@@ -6,11 +6,7 @@
 typedef void (^ARAuthorizationBlock)(PKPaymentAuthorizationStatus);
 typedef void (^ARListUpdateBlock)(PKPaymentAuthorizationStatus, NSArray<PKShippingMethod *>*, NSArray<PKPaymentSummaryItem *>*);
 
-@interface CDVApplePay : CDVPlugin <PKPaymentAuthorizationViewControllerDelegate>
-{
-    PKMerchantCapability merchantCapabilities;
-    NSArray<NSString *>* supportedPaymentNetworks;
-}
+@interface CDVApplePay : CDVPlugin <PKPaymentAuthorizationViewControllerDelegate> {}
 
 @property (nonatomic, strong) ARAuthorizationBlock paymentAuthorizationBlock;
 

--- a/src/ios/CDVApplePay.m
+++ b/src/ios/CDVApplePay.m
@@ -5,19 +5,6 @@
 
 @synthesize paymentCallbackId;
 
-
-- (void)pluginInitialize
-{
-    
-    // Set these to the payment cards accepted.
-    // They will nearly always be the same.
-    supportedPaymentNetworks = @[PKPaymentNetworkVisa, PKPaymentNetworkMasterCard, PKPaymentNetworkAmex];
-    
-    // Set the capabilities that your merchant supports
-    // Adyen for example, only supports the 3DS one.
-    merchantCapabilities = PKMerchantCapability3DS;// PKMerchantCapabilityEMV;
-}
-
 - (void)canMakePayments:(CDVInvokedUrlCommand*)command
 {
     if ([PKPaymentAuthorizationViewController canMakePayments]) {
@@ -26,12 +13,32 @@
             [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
             return;
         } else if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 0, 0}]) {
-            if ([PKPaymentAuthorizationViewController canMakePaymentsUsingNetworks:supportedPaymentNetworks capabilities:(merchantCapabilities)]) {
-                CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @"This device can make payments and has a supported card"];
-                [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
-                return;
-            } else {
-                CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"This device can make payments but has no supported cards"];
+            if (command.arguments[0] != [NSNull null] && [command.arguments[0] objectForKey:@"supportedNetworks"] != nil) {
+                if ([command.arguments[0] objectForKey:@"merchantCapabilities"] != nil) {
+                    if ([PKPaymentAuthorizationViewController
+                            canMakePaymentsUsingNetworks:[self supportedNetworksFromArguments:command.arguments]
+                                            capabilities:[self merchantCapabilitiesFromArguments:command.arguments]]) {
+                        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @"This device can make payments and has a supported card."];
+                        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+                        return;
+                    } else {
+                        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"This device can make payments but has no supported card."];
+                        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+                        return;
+                    }
+                } else { // merchantCapabilities is nil
+                    if ([PKPaymentAuthorizationViewController canMakePaymentsUsingNetworks:[self supportedNetworksFromArguments:command.arguments]]) {
+                        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @"This device can make payments and has a supported card."];
+                        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+                        return;
+                    } else {
+                        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"This device can make payments but has no supported card."];
+                        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+                        return;
+                    }
+                }
+            } else { // supportedNetworks is nil
+                CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @"This device can make payments."];
                 [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
                 return;
             }
@@ -68,7 +75,7 @@
 - (PKShippingType)shippingTypeFromArguments:(NSArray *)arguments
 {
     NSString *shippingType = [[arguments objectAtIndex:0] objectForKey:@"shippingType"];
-    
+
     if ([shippingType isEqualToString:@"shipping"]) {
         return PKShippingTypeShipping;
     } else if ([shippingType isEqualToString:@"delivery"]) {
@@ -78,8 +85,8 @@
     } else if ([shippingType isEqualToString:@"service"]) {
         return PKShippingTypeServicePickup;
     }
-    
-    
+
+
     return PKShippingTypeShipping;
 }
 
@@ -87,7 +94,7 @@
 {
     NSArray *billingAddressRequirement = [[arguments objectAtIndex:0] objectForKey:@"billingAddressRequirement"];
     PKAddressField requiredFields = PKAddressFieldNone;
-    
+
     for (id requirement in billingAddressRequirement) {
         if ([requirement isEqualToString:@"all"]) {
             requiredFields = requiredFields | PKAddressFieldAll;
@@ -101,7 +108,7 @@
             requiredFields = requiredFields | PKAddressFieldPhone;
         }
     }
-    
+
     return requiredFields;
 }
 
@@ -109,7 +116,7 @@
 {
     NSArray *shippingAddressRequirements = [[arguments objectAtIndex:0] objectForKey:@"shippingAddressRequirement"];
     PKAddressField requiredFields = PKAddressFieldNone;
-    
+
     for (id requirement in shippingAddressRequirements) {
         if ([requirement isEqualToString:@"all"]) {
             requiredFields = requiredFields | PKAddressFieldAll;
@@ -123,56 +130,99 @@
             requiredFields = requiredFields | PKAddressFieldPhone;
         }
     }
-    
+
     return requiredFields;
 }
 
 - (NSArray *)itemsFromArguments:(NSArray *)arguments
 {
     NSArray *itemDescriptions = [[arguments objectAtIndex:0] objectForKey:@"items"];
-    
+
     NSMutableArray *items = [[NSMutableArray alloc] init];
-    
+
     for (NSDictionary *item in itemDescriptions) {
-        
+
         NSString *label = [item objectForKey:@"label"];
-        
+
         NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithDecimal:[[item objectForKey:@"amount"] decimalValue]];
-        
+
         PKPaymentSummaryItem *newItem = [PKPaymentSummaryItem summaryItemWithLabel:label amount:amount];
-        
+
         [items addObject:newItem];
     }
-    
+
     return items;
+}
+
+- (PKMerchantCapability)merchantCapabilitiesFromArguments:(NSArray *)arguments
+{
+    NSArray *capabilities = [arguments[0] objectForKey:@"merchantCapabilities"];
+
+    PKMerchantCapability merchantCapability = 0;
+
+    for (NSString *capability in capabilities) {
+        if ([capability isEqualToString:@"3ds"]) {
+            merchantCapability |= PKMerchantCapability3DS;
+        } else if ([capability isEqualToString:@"credit"]) {
+            merchantCapability |= PKMerchantCapabilityCredit;
+        } else if ([capability isEqualToString:@"debit"]) {
+            merchantCapability |= PKMerchantCapabilityDebit;
+        } else if ([capability isEqualToString:@"emv"]) {
+            merchantCapability |= PKMerchantCapabilityEMV;
+        }
+    }
+
+    return merchantCapability;
+}
+
+- (NSArray<NSString *>*)supportedNetworksFromArguments:(NSArray *)arguments
+{
+    NSArray *networks = [arguments[0] objectForKey:@"supportedNetworks"];
+
+    NSMutableArray<NSString *>* paymentNetworks = [[NSMutableArray alloc] init];
+
+    for (NSString *network in networks) {
+        if ([network isEqualToString:@"visa"]) {
+            [paymentNetworks addObject:PKPaymentNetworkVisa];
+        } else if ([network isEqualToString:@"discover"]) {
+            [paymentNetworks addObject:PKPaymentNetworkDiscover];
+        } else if ([network isEqualToString:@"masterCard"]) {
+            [paymentNetworks addObject:PKPaymentNetworkMasterCard];
+        } else if ([network isEqualToString:@"amex"]) {
+            [paymentNetworks addObject:PKPaymentNetworkAmex];
+        }
+        // TODO: add the rest
+    }
+
+    return paymentNetworks;
 }
 
 - (NSArray *)shippingMethodsFromArguments:(NSArray *)arguments
 {
     NSArray *shippingDescriptions = [[arguments objectAtIndex:0] objectForKey:@"shippingMethods"];
-    
+
     NSMutableArray *shippingMethods = [[NSMutableArray alloc] init];
-    
-    
+
+
     for (NSDictionary *desc in shippingDescriptions) {
-        
+
         NSString *identifier = [desc objectForKey:@"identifier"];
         NSString *detail = [desc objectForKey:@"detail"];
         NSString *label = [desc objectForKey:@"label"];
-        
+
         NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithDecimal:[[desc objectForKey:@"amount"] decimalValue]];
-        
+
         PKPaymentSummaryItem *newMethod = [self shippingMethodWithIdentifier:identifier detail:detail label:label amount:amount];
-        
+
         [shippingMethods addObject:newMethod];
     }
-    
+
     return shippingMethods;
 }
 
 - (PKPaymentAuthorizationStatus)paymentAuthorizationStatusFromArgument:(NSString *)paymentAuthorizationStatus
 {
-    
+
     if ([paymentAuthorizationStatus isEqualToString:@"success"]) {
         return PKPaymentAuthorizationStatusSuccess;
     } else if ([paymentAuthorizationStatus isEqualToString:@"failure"]) {
@@ -190,51 +240,48 @@
     } else if ([paymentAuthorizationStatus isEqualToString:@"locked-pin"]) {
         return PKPaymentAuthorizationStatusPINLockout;
     }
-    
+
     return PKPaymentAuthorizationStatusFailure;
 }
 
 - (void)completeLastTransaction:(CDVInvokedUrlCommand*)command
 {
     if (self.paymentAuthorizationBlock) {
-        
+
         NSString *paymentAuthorizationStatusString = [command.arguments objectAtIndex:0];
         NSLog(@"ApplePay completeLastTransaction == %@", paymentAuthorizationStatusString);
-        
+
         PKPaymentAuthorizationStatus paymentAuthorizationStatus = [self paymentAuthorizationStatusFromArgument:paymentAuthorizationStatusString];
         self.paymentAuthorizationBlock(paymentAuthorizationStatus);
-        
+
         CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @"Payment status applied."];
         [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
-        
+
     }
 }
 
 - (void)makePaymentRequest:(CDVInvokedUrlCommand*)command
 {
     self.paymentCallbackId = command.callbackId;
-    
+
     NSLog(@"ApplePay canMakePayments == %s", [PKPaymentAuthorizationViewController canMakePayments]? "true" : "false");
     if ([PKPaymentAuthorizationViewController canMakePayments] == NO) {
         CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"This device cannot make payments."];
         [self.commandDelegate sendPluginResult:result callbackId:self.paymentCallbackId];
         return;
     }
-    
+
     // reset any lingering callbacks, incase the previous payment failed.
     self.paymentAuthorizationBlock = nil;
-    
+
     PKPaymentRequest *request = [PKPaymentRequest new];
-    
-    // Different version of iOS support different networks, (ie Discover card is iOS9+; not part of my project, so ignoring).
-    request.supportedNetworks = supportedPaymentNetworks;
-    
-    request.merchantCapabilities = merchantCapabilities;
-    
+
     // All this data is loaded from the Cordova object passed in. See documentation.
     [request setCurrencyCode:[self currencyCodeFromArguments:command.arguments]];
     [request setCountryCode:[self countryCodeFromArguments:command.arguments]];
     [request setMerchantIdentifier:[self merchantIdentifierFromArguments:command.arguments]];
+    [request setMerchantCapabilities:[self merchantCapabilitiesFromArguments:command.arguments]];
+    [request setSupportedNetworks:[self supportedNetworksFromArguments:command.arguments]];
     [request setRequiredBillingAddressFields:[self billingAddressRequirementFromArguments:command.arguments]];
     [request setRequiredShippingAddressFields:[self shippingAddressRequirementFromArguments:command.arguments]];
     [request setShippingType:[self shippingTypeFromArguments:command.arguments]];
@@ -242,19 +289,19 @@
     [request setPaymentSummaryItems:[self itemsFromArguments:command.arguments]];
     self.shippingMethods = [self shippingMethodsFromArguments:command.arguments];
     self.summaryItems = [self itemsFromArguments:command.arguments];
-    
+
     NSLog(@"ApplePay request == %@", request);
-    
+
     PKPaymentAuthorizationViewController *authVC = [[PKPaymentAuthorizationViewController alloc] initWithPaymentRequest:request];
-    
+
     authVC.delegate = self;
-    
+
     if (authVC == nil) {
         CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"PKPaymentAuthorizationViewController was nil."];
         [self.commandDelegate sendPluginResult:result callbackId:self.paymentCallbackId];
         return;
     }
-    
+
     [self.viewController presentViewController:authVC animated:YES completion:nil];
 }
 
@@ -275,21 +322,21 @@
 - (void)paymentAuthorizationViewControllerDidFinish:(PKPaymentAuthorizationViewController *)controller
 {
     [self.viewController dismissViewControllerAnimated:YES completion:nil];
-    
+
     CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString: @"Payment not completed."];
     [self.commandDelegate sendPluginResult:result callbackId:self.paymentCallbackId];
 }
 
 - (NSDictionary*) formatPaymentForApplication:(PKPayment *)payment {
     NSString *paymentData = [payment.token.paymentData base64EncodedStringWithOptions:0];
-    
+
     //    NSDictionary *response = @{
     //                               @"paymentData":paymentData,
     //                               @"transactionIdentifier":payment.token.transactionIdentifier
     //                               };
-    
+
     NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
-    
+
     [response setObject:paymentData  forKey:@"paymentData"];
     [response setObject:payment.token.transactionIdentifier  forKey:@"transactionIdentifier"];
 
@@ -299,145 +346,145 @@
     NSString *typeCard = nil;
 
     switch(payment.token.paymentMethod.type) {
-            case PKPaymentMethodTypeUnknown:
-                typeCard = @"unknown"; // The card’s type is not known.
-                break;
-            case PKPaymentMethodTypeDebit:
-                typeCard = @"debit"; // A debit card.
-                break;
-            case PKPaymentMethodTypeCredit:
-                typeCard = @"credit";// A credit card.
-                break;
-            case PKPaymentMethodTypePrepaid:
-                typeCard = @"prepaid";// A prepaid card.
-                break;
-            case PKPaymentMethodTypeStore:
-                typeCard = @"store";// A store card.
-                break;
-            default:
-                typeCard = @"error";// A store card.
-        }
+        case PKPaymentMethodTypeUnknown:
+            typeCard = @"unknown"; // The card’s type is not known.
+            break;
+        case PKPaymentMethodTypeDebit:
+            typeCard = @"debit"; // A debit card.
+            break;
+        case PKPaymentMethodTypeCredit:
+            typeCard = @"credit";// A credit card.
+            break;
+        case PKPaymentMethodTypePrepaid:
+            typeCard = @"prepaid";// A prepaid card.
+            break;
+        case PKPaymentMethodTypeStore:
+            typeCard = @"store";// A store card.
+            break;
+        default:
+            typeCard = @"error";// A store card.
+    }
 
     [response setObject:typeCard  forKey:@"paymentMethodTypeCard"];
-    
+
     PKContact *billingContact = payment.billingContact;
     if (billingContact) {
         if (billingContact.emailAddress) {
             [response setObject:billingContact.emailAddress forKey:@"billingEmailAddress"];
         }
-        
+
         if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 2, 0}]) {
             if (billingContact.supplementarySubLocality) {
                 [response setObject:billingContact.supplementarySubLocality forKey:@"billingSupplementarySubLocality"];
             }
         }
-        
+
         if (billingContact.name) {
-            
+
             if (billingContact.name.givenName) {
                 [response setObject:billingContact.name.givenName forKey:@"billingNameFirst"];
             }
-            
+
             if (billingContact.name.middleName) {
                 [response setObject:billingContact.name.middleName forKey:@"billingNameMiddle"];
             }
-            
+
             if (billingContact.name.familyName) {
                 [response setObject:billingContact.name.familyName forKey:@"billingNameLast"];
             }
-            
+
         }
-        
+
         if (billingContact.postalAddress) {
-            
+
             if (billingContact.postalAddress.street) {
                 [response setObject:billingContact.postalAddress.street forKey:@"billingAddressStreet"];
             }
-            
+
             if (billingContact.postalAddress.city) {
                 [response setObject:billingContact.postalAddress.city forKey:@"billingAddressCity"];
             }
-            
+
             if (billingContact.postalAddress.state) {
                 [response setObject:billingContact.postalAddress.state forKey:@"billingAddressState"];
             }
-            
-            
+
+
             if (billingContact.postalAddress.postalCode) {
                 [response setObject:billingContact.postalAddress.postalCode forKey:@"billingPostalCode"];
             }
-            
+
             if (billingContact.postalAddress.country) {
                 [response setObject:billingContact.postalAddress.country forKey:@"billingCountry"];
             }
-            
+
             if (billingContact.postalAddress.ISOCountryCode) {
                 [response setObject:billingContact.postalAddress.ISOCountryCode forKey:@"billingISOCountryCode"];
             }
-            
+
         }
     }
-    
+
     PKContact *shippingContact = payment.shippingContact;
     if (shippingContact) {
         if (shippingContact.emailAddress) {
             [response setObject:shippingContact.emailAddress forKey:@"shippingEmailAddress"];
         }
-        
+
         if (shippingContact.phoneNumber) {
             [response setObject:shippingContact.phoneNumber.stringValue forKey:@"shippingPhoneNumber"];
         }
-        
+
         if (shippingContact.name) {
-            
+
             if (shippingContact.name.givenName) {
                 [response setObject:shippingContact.name.givenName forKey:@"shippingNameFirst"];
             }
-            
+
             if (shippingContact.name.middleName) {
                 [response setObject:shippingContact.name.middleName forKey:@"shippingNameMiddle"];
             }
-            
+
             if (shippingContact.name.familyName) {
                 [response setObject:shippingContact.name.familyName forKey:@"shippingNameLast"];
             }
-            
+
         }
         if ([[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9, 2, 0}]) {
             if (shippingContact.supplementarySubLocality) {
                 [response setObject:shippingContact.supplementarySubLocality forKey:@"shippingSupplementarySubLocality"];
             }
         }
-        
+
         if (shippingContact.postalAddress) {
-            
+
             if (shippingContact.postalAddress.street) {
                 [response setObject:shippingContact.postalAddress.street forKey:@"shippingAddressStreet"];
             }
-            
+
             if (shippingContact.postalAddress.city) {
                 [response setObject:shippingContact.postalAddress.city forKey:@"shippingAddressCity"];
             }
-            
+
             if (shippingContact.postalAddress.state) {
                 [response setObject:shippingContact.postalAddress.state forKey:@"shippingAddressState"];
             }
-            
+
             if (shippingContact.postalAddress.postalCode) {
                 [response setObject:shippingContact.postalAddress.postalCode forKey:@"shippingPostalCode"];
             }
-            
+
             if (shippingContact.postalAddress.country) {
                 [response setObject:shippingContact.postalAddress.country forKey:@"shippingCountry"];
             }
-            
+
             if (shippingContact.postalAddress.ISOCountryCode) {
                 [response setObject:shippingContact.postalAddress.ISOCountryCode forKey:@"shippingISOCountryCode"];
             }
-            
+
         }
     }
-    
+
     return response;
 }
 
@@ -446,12 +493,12 @@
                                 completion:(void (^)(PKPaymentAuthorizationStatus status))completion
 {
     NSLog(@"CDVApplePay: didAuthorizePayment");
-    
+
     if (completion) {
         self.paymentAuthorizationBlock = completion;
     }
     NSDictionary* response = [self formatPaymentForApplication:payment];
-    
+
     CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:response];
     [self.commandDelegate sendPluginResult:result callbackId:self.paymentCallbackId];
 }
@@ -466,15 +513,15 @@
             if (contact.postalAddress.city) {
                 [response setObject:contact.postalAddress.city forKey:@"shippingAddressCity"];
             }
-            
+
             if (contact.postalAddress.state) {
                 [response setObject:contact.postalAddress.state forKey:@"shippingAddressState"];
             }
-            
+
             if (contact.postalAddress.postalCode) {
                 [response setObject:contact.postalAddress.postalCode forKey:@"shippingPostalCode"];
             }
-            
+
             if (contact.postalAddress.ISOCountryCode) {
                 [response setObject:[contact.postalAddress.ISOCountryCode uppercaseString] forKey:@"shippingISOCountryCode"];
             }
@@ -512,7 +559,7 @@
     shippingMethod.detail = detail;
     shippingMethod.amount = amount;
     shippingMethod.label = label;
-    
+
     return shippingMethod;
 }
 

--- a/www/applepay.js
+++ b/www/applepay.js
@@ -1,6 +1,6 @@
 var argscheck = require('cordova/argscheck'),
-    utils = require('cordova/utils'),
-    exec = require('cordova/exec');
+  utils = require('cordova/utils'),
+  exec = require('cordova/exec');
 
 var executeCallback = function(callback, message) {
     if (typeof callback === 'function') {
@@ -15,7 +15,12 @@ var ApplePay = {
      * @param {Function} [errorCallback] - Optional error callback, recieves message object.
      * @returns {Promise}
      */
-    canMakePayments: function(successCallback, errorCallback) {
+    canMakePayments: function(query, successCallback, errorCallback) {
+        if (typeof query == 'function') { // missing query, method is invoked with two function args only
+            errorCallback = successCallback;
+            successCallback = query;
+            query = {}
+        }
         return new Promise(function(resolve, reject) {
             exec(function(message) {
                 executeCallback(successCallback, message);
@@ -23,10 +28,10 @@ var ApplePay = {
             }, function(message) {
                 executeCallback(errorCallback, message);
                 reject(message);
-            }, 'ApplePay', 'canMakePayments', []);
+            }, 'ApplePay', 'canMakePayments', [query]);
         });
     },
-
+    
     /**
      * Opens the Apple Pay sheet and shows the order information.
      * @param {Function} [successCallback] - Optional success callback, recieves message object.
@@ -50,7 +55,7 @@ var ApplePay = {
             }, 'ApplePay', 'makePaymentRequest', [order]);
         });
     },
-
+    
     /**
      * Starts listening for shipping contact selection changes
      * Any time the user selects shipping contact, this callback will fire.
@@ -69,7 +74,7 @@ var ApplePay = {
             executeCallback(errorCallback, message);
         }, 'ApplePay', 'startListeningForShippingContactSelection');
     },
-
+    
     /**
      * Stops listening for shipping contact selection changes
      * @param {Function} [successCallback] - Optional success callback
@@ -87,7 +92,7 @@ var ApplePay = {
             }, 'ApplePay', 'stopListeningForShippingContactSelection');
         });
     },
-
+    
     /**
      * Update the list of pay sheet items and shipping methods in response to
      * a shipping contact selection event. This *must* be called in response to
@@ -109,7 +114,7 @@ var ApplePay = {
             }, 'ApplePay', 'updateItemsAndShippingMethods', [list]);
         });
     },
-
+    
     /**
      * While the Apple Pay sheet is still open, and the callback from the `makePaymentRequest` has completed,
      * this call will pass the status to the sheet and close it if successfull.


### PR DESCRIPTION
### What I did
I made the supported networks and merchant capabilities configurable by changing the `canMakePayments()` and `makePaymentRequest()` APIs. Please see the updated README for examples.

To comply with semver I increased the major version of the library because the `makePaymentRequest()` method now expects the `supportedNetworks` and `merchantCapabilities` options in its input.

Please forgive me my Objective-C infancy. This is the very first time I have seen and touched this language so my solution needs critical eyes.
