### PR TITLE
Add support for pending summary item

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,14 @@ ApplePay.makePaymentRequest(
                   label: 'Next Day Delivery',
                   amount: 3.99
               },
-                      {
+              {
                   label: 'My Fashion Company',
                   amount: 53.98
+              },
+              {
+                  label: 'Item with pending amount',
+                  amount: 0.00,
+                  type: 'pending'
               }
           ],
           shippingMethods: [

--- a/src/ios/CDVApplePay.m
+++ b/src/ios/CDVApplePay.m
@@ -146,7 +146,9 @@
 
         NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithDecimal:[[item objectForKey:@"amount"] decimalValue]];
 
-        PKPaymentSummaryItem *newItem = [PKPaymentSummaryItem summaryItemWithLabel:label amount:amount];
+        PKPaymentSummaryItemType type = [[item objectForKey:@"type"] isEqualToString:@"pending"] ? PKPaymentSummaryItemTypePending : PKPaymentSummaryItemTypeFinal;
+
+        PKPaymentSummaryItem *newItem = [PKPaymentSummaryItem summaryItemWithLabel:label amount:amount type:type];
 
         [items addObject:newItem];
     }


### PR DESCRIPTION
Adds ability to set `type` on payment summary items to `pending`. Useful when the final charge will be determined by time or other dynamic variable. Usually seen in taxi and scooter renting apps.

<img src="https://github.com/samkelleher/cordova-plugin-applepay/assets/909826/17748beb-3f55-40da-9b0b-f3a5660958fa" width="400">
